### PR TITLE
Use builder xml instance in template

### DIFF
--- a/app/views/spree/shipstation/export.xml.builder
+++ b/app/views/spree/shipstation/export.xml.builder
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-xml = Builder::XmlMarkup.new
 xml.instruct!
 xml.Orders(pages: (@shipments.total_count / 50.0).ceil) {
   @shipments.each do |shipment|


### PR DESCRIPTION
**TL;DR**

Shipstationがecのオーダーを読み込めなくなってしまうのを修正します。

**原因**

現在の方法では出荷していないオーダーのリストをxmlで出力したものをshipstationが定期的に読み込みます。
Xmlの出力には`export.xml.builder` viewを使用し、`Builder::XmlMarkup`でオーダーをxmlに変換しています。

Railsの標準的な挙動で特に変わったところはないと思われたのですが、
Templateの冒頭で
```
xml = Builder::XmlMarkup.new
```
をしていました。

Rails 7.1で`action_view/template/handlers/builder.rb`がアップデートされていて、
viewの中で新たにxmlインスタンスを作ると何も出力されないようになってまいました。

PRはこちらです。
https://github.com/rails/rails/pull/45731

そもそもview templateの中で新しいXmlMarkupインスタンスを作る必要はなかったのかもしれないです。
Json jbuilderのview templateの場合はいつも`json`がすでに使えるようになっているので、少し不思議に思いながら使用していましたが、今回の件を踏まえると同じような仕組みなのかと思いました。
（すいません、そこまでちゃんと見て確認していません。）

問題を解明するのにものすごい時間がかかってしまい、今回こそは諦めかけました😅

下記がコードの変更内容です。

[Rails 7.1](https://github.com/rails/rails/blob/v7.1.3/actionview/lib/action_view/template/handlers/builder.rb)
```
def call(template, source)
        require_engine
        # the double assignment is to silence "assigned but unused variable" warnings
        "xml = xml = ::Builder::XmlMarkup.new(indent: 2, target: output_buffer.raw);" \
          "#{source};" \
          "output_buffer.to_s"
      end
```

[Rails 7.0.7](https://github.com/rails/rails/blob/v7.0.7/actionview/lib/action_view/template/handlers/builder.rb)
```
def call(template, source)
        require_engine
        "xml = ::Builder::XmlMarkup.new(:indent => 2);" \
          "self.output_buffer = xml.target!;" +
          source +
          ";xml.target!;"
      end
```
